### PR TITLE
[FE] hotfix: 여행 스케줄 생성 데이터 값 변경

### DIFF
--- a/src/api/axios.js
+++ b/src/api/axios.js
@@ -6,6 +6,7 @@ import router from "@/router";
 
 const myaxios = axios.create({
   baseURL: "https://inssaroute.shop/api",
+  // baseURL: "http://localhost:8080/api",
   headers: {
     "Content-Type": "application/json",
   },

--- a/src/stores/planStores.js
+++ b/src/stores/planStores.js
@@ -138,7 +138,7 @@ export const usePlanStore = defineStore('plan', () => {
         time: scheduleTime.value,
         memo: scheduleMemo.value,
         estimatedCost: Number(estimatedCost.value),
-        attractionId: selectedSpot.value.contentId,
+        attractionId: selectedSpot.value.no,
         date: selectedDate.value
       };
       


### PR DESCRIPTION


## 진행내용
-  스케줄 생성시에 attraction_id 대신 content_id 보내는 오류 해결